### PR TITLE
Add electron support

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     if (type === 'head') {
       if (config.googleFonts) {
         var families = config.googleFonts.join('|');
-        return '<link href="//fonts.googleapis.com/css?family=' + families + '" rel="stylesheet" type="text/css" media="all">';
+        return '<link href="https://fonts.googleapis.com/css?family=' + families + '" rel="stylesheet" type="text/css" media="all">';
       }
     }
   }


### PR DESCRIPTION
Without explicitly writing `https` in the `href` of the `<link>` element injected into `index.html` electron will interpret it as a `file://` URL. Adding `https` enables use with Electron and does not break normal use with `ember serve`.
